### PR TITLE
Fix CF Target URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ cd cf-ex-wordpress
 
 ```bash
 # Set the target to tell Cloud Foundry which api to use (this will be different if you are not using an account hosted by Cloud Foundry)
-cf target api.pivotal.run.io
+cf target api.run.pivotal.io
 
 # Login
 cf login


### PR DESCRIPTION
Not sure if cf recently changed their api url or if I set the wrong target initially, but this is the URL that works correctly now
