### PR TITLE
Added .bp-config/options.json to allow for loading of mysqli extension

### DIFF
--- a/.bp-config/options.json
+++ b/.bp-config/options.json
@@ -1,0 +1,4 @@
+{
+    "ADMIN_EMAIL": "dan@mikusa.com",
+    "PHP_EXTENSIONS": ["mbstring", "mysqli", "mcrypt", "gd", "zip"]
+}


### PR DESCRIPTION
This addition prevented my installation from displaying the following error message following a "cf push":

Your PHP installation appears to be missing the MySQL extension which is required by WordPress.
